### PR TITLE
Portfolio styling adjustment

### DIFF
--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -1,4 +1,28 @@
-/* Mobile Version */
+.projectLinks {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    margin-top: 0.5rem;
+}
+
+.projectName {
+    font-weight: bold;
+    font-size: 1.25rem;
+    text-align: center;
+    margin-top: 0.25rem;
+}
+
+.projectDescription {
+    font-size: 20px;
+}
+
+.projectLinks>a>img:hover{
+    height: 70px;
+    width: 70px;
+}
+
+/* Mobile Portfolio Cards Styling */
 @media screen and (max-width: 768px) {
     .allProjects {
         display: grid;
@@ -18,7 +42,7 @@
     }
 }
 
-/* Tablet Version */
+/* Tablet Portfolio Cards Styling */
 @media screen and (min-width: 768px) {
     .allProjects {
         display: grid;
@@ -36,7 +60,7 @@
     }
 }
 
-/* Desktop Version */
+/* Desktop Portfolio Cards Styling */
 @media screen and (min-width: 992px) {
     .allProjects {
         display: grid;
@@ -49,25 +73,6 @@
     }
 
     .projectThumbnail {
-        height: 250px;
+        height: 225px;
     }
-}
-
-.projectLinks {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-around;
-    margin-top: 0.5rem;
-}
-
-.projectName {
-    font-weight: bold;
-    font-size: 1.25rem;
-    text-align: center;
-    margin-top: 0.25rem;
-}
-
-.projectDescription {
-    font-size: 20px;
 }


### PR DESCRIPTION
This update places non-media-based stylings at the top of the stylesheet for the portfolio cards. In addition, the linked icons to the project GitHub repos and deployed sites/demo videos now grow bigger upon hovering. In addition, the desktop thumbnail images were slightly decreased.