### PR TITLE
Nav bar restyle

### DIFF
--- a/src/components/NavTabs.js
+++ b/src/components/NavTabs.js
@@ -6,8 +6,8 @@ export default function NavTabs({ currentPage, handlePageChange }) {
     <header>
       <Navbar collapseOnSelect expand='lg'>
         <Container>
+        <Navbar.Brand><h1>Claire Lee</h1></Navbar.Brand>
           <Navbar.Toggle aria-controls='basic-navbar-nav' />
-          <h1>Claire Lee</h1>
           <Navbar.Collapse id='basic-navbar-nav'>
             <Nav className="me-auto">
               {/* <Nav.Link href='#home'
@@ -30,6 +30,8 @@ export default function NavTabs({ currentPage, handlePageChange }) {
                 className={currentPage === 'Contact' ? 'nav-link active' : 'nav-link'}>
                 Contact
               </Nav.Link>
+            </Nav>
+            <Nav>
               <button className="button">
                 <a href={require("./resumes/Lee_Claire_Resume.pdf")} download>
                   Download Resume

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -57,6 +57,32 @@ body {
     .contentWrapper {
         padding-bottom: 10rem
     }
+
+    .nav-link {
+        text-align: center;
+    }
+
+    /* Resume button stylings */
+    .button {
+        background-color: transparent;
+        border: var(--text-color) 1px dashed;
+        border-radius: 5px;
+        text-decoration: none;
+    }
+
+    .button>a {
+        text-decoration: none;
+        color: var(--text-color);
+    }
+
+    .button>a:active {
+        text-decoration: none;
+        color: var(--text-color);
+    }
+
+    nav{
+        padding: 12px !important;
+    }
 }
 
 /*Desktop layout*/
@@ -69,8 +95,25 @@ body {
 
     /* Resume button stylings */
     .button {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
         background-color: transparent;
         border: var(--text-color) 1px dashed;
         border-radius: 5px;
+    }
+
+    .button>a {
+        text-decoration: none;
+        color: var(--text-color);
+    }
+
+    .button>a:active {
+        text-decoration: none;
+        color: var(--text-color);
+    }
+
+    nav{
+        padding: 3.75px !important;
     }
 }


### PR DESCRIPTION
This update rearranges the navbar contents to have my name on the left-hand side regardless of the media screen width as a navbar brand. The button to download the resume has been moved to the right-hand side on desktop sizes to distinguish it from the navbar anchors that render the other pages. The blue text-decoration has been disabled for this button as well.