### PR TITLE
Changes stylings for medias 992px wide and adds for 1400px wide devices

### DIFF
--- a/src/styles/cards.css
+++ b/src/styles/cards.css
@@ -17,7 +17,7 @@
     font-size: 20px;
 }
 
-.projectLinks>a>img:hover{
+.projectLinks>a>img:hover {
     height: 70px;
     width: 70px;
 }
@@ -60,8 +60,33 @@
     }
 }
 
+
 /* Desktop Portfolio Cards Styling */
 @media screen and (min-width: 992px) {
+    .allProjects {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-template-rows: 1fr 1fr 1fr;
+    }
+
+    .project {
+        margin-bottom: 1rem;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+
+    .projectDescription {
+        margin-left: 30px;
+    }
+
+    .projectThumbnail {
+        height: 250px;
+    }
+}
+
+@media screen and (min-width: 1400px) {
     .allProjects {
         display: grid;
         grid-template-columns: 1fr 1fr 1fr;


### PR DESCRIPTION
This update changes the portfolio page layout on devices 992px wide to be a 2-column x 3-row grid, similar to devices at least 768px wide. Devices that are at least 1400 px wide now have the 3-column x 2-row grid layout.