### PR TITLE
Completes the responsive stylings for Contact Me form

### DIFF
--- a/src/styles/form.css
+++ b/src/styles/form.css
@@ -128,9 +128,9 @@ label {
 @media screen and (max-width:768px) {
     .rightTape {
         transform: rotate(-90deg);
-        height: 768px;
-        bottom: 14rem;
-        left: 10rem;
+        height: 650px;
+        bottom: 17rem;
+        left: 11.55rem;
     }
 
     .leftTape {


### PR DESCRIPTION
This update completes the responsive stylings for the Contact Me form by adjusting the washi tape styled `div` element on mobile devices with screens less than 768px.